### PR TITLE
Bugfix: BytesIO used instead of cStringIO

### DIFF
--- a/example/requirements/base.txt
+++ b/example/requirements/base.txt
@@ -4,7 +4,7 @@ XlsxWriter==0.7.7
 python-mimeparse==0.1.4
 pep8==1.6.2
 six==1.10.0
-https://github.com/xhtml2pdf/xhtml2pdf/tarball/python3
+https://github.com/xhtml2pdf/xhtml2pdf/tarball/master#egg=master
 https://github.com/LukasRychtecky/germanium/tarball/1.0.4#egg=germanium-1.0.4
 https://github.com/matllubos/django-piston/tarball/1.2.10#egg=django-piston-1.2.10
 coverage==4.0.2

--- a/piston/data_processor.py
+++ b/piston/data_processor.py
@@ -2,7 +2,7 @@ import sys
 import base64
 import inspect
 
-from six.moves import cStringIO
+from six import BytesIO
 
 from django.forms.fields import FileField
 from django.utils.translation import ugettext_lazy as _, ugettext
@@ -80,7 +80,7 @@ class FileDataPreprocessor(DataProcessor):
     def _process_file_data_field(self, data, files, key, data_item):
         try:
             filename = data_item.get('filename')
-            file_content = cStringIO(base64.b64decode(data_item.get('content')).decode('utf-8'))
+            file_content = BytesIO(base64.b64decode(data_item.get('content').encode('utf-8')))
             content_type = data_item.get('content_type')
             charset = data_item.get('charset')
             files[key] = InMemoryUploadedFile(


### PR DESCRIPTION
- fixes a problem with receiving base64 images in Python 3.
- requirements updated
